### PR TITLE
Fix for installation on MacOS Ventura

### DIFF
--- a/difmap.rb
+++ b/difmap.rb
@@ -30,6 +30,10 @@ class Difmap < Formula
       s.change_make_var! "PGPLOT_LIB", pgplotlib
     end
 
+    if (system 'sw_vers -productVersion').to_f >= 13.0
+      inreplace "configure", "(cd libtecla_src; ./configure --without-man-pages)", "(cd libtecla_src ./configure --without-man-pages CFLAGS=-mmacosx-version-min=12.4.0)"
+    end
+
     system "./configure", "intel-osx-gcc"
     system "./makeall"
 


### PR DESCRIPTION
 Hi @kazuakiyama, I'm working with @rmutel and ran into issues installing pgplot and difmap on MacOS Ventura (v13.0.1 on MacBook Pro M1). I managed to modify your scripts to allow for installation. The error is primarily due to the make files for both pgplot and difmap handing the C compiler GCC the OS version (seemingly pointlessly). Since the latest version of GCC doesn't understand an input of anything above 12.4.x, it breaks. I made modifications to check the current version and override the appropriate flag if necessary. This shouldn't impact anyone below Ventura. See the pull request on the [pgplot repository](https://github.com/WWGolay/homebrew-pgplot) as well. 

Cheers,

WWG